### PR TITLE
User alerted to error if checkin does not return success

### DIFF
--- a/Software/Database-Server_Software/www/v1/OVLcheckinout.js
+++ b/Software/Database-Server_Software/www/v1/OVLcheckinout.js
@@ -48,21 +48,32 @@ document.addEventListener('DOMContentLoaded', function(){
             method: 'POST',
             body: formData
         })
-        .then(response => response.text())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was ' + response.status + ' ' + response.statusText);
+            } else {
+                
+                // Check if the person has signed the waiver
+                if (this.elements['hasSignedWaiver'].value == 0 ) {
+                    // Clear the form
+                    this.reset();
+                    alertUser("You will now go to the waiver page.", "blue",1000)
+                    window.location.href = "https://app.waiversign.com/e/6421facd543e76001945bf5c/doc/6421fb7d543e76001945c3cb?event=none";
+                } else {
+                    // Clear the form
+                    this.reset();
+                    alertUser("You have been checked in. Thank you.", "green", 2000);
+                    window.location.href = "https://makernexus.org";
+                }
+            }
+        })
         .then(data => console.log(data))
-        .catch((error) => console.error('Error:', error));
+        .catch((error) => {
+            console.error('Error:', error);
+            alertUser("An error occurred: " + error + " ... Please try again.", "red");
+        });
 
-        if (this.elements['hasSignedWaiver'].value == 0 ) {
-            // Clear the form
-            this.reset();
-            alertUser("You will now go to the waiver page.", "blue",1000)
-            window.location.href = "https://app.waiversign.com/e/6421facd543e76001945bf5c/doc/6421fb7d543e76001945c3cb?event=none";
-        } else {
-            // Clear the form
-            this.reset();
-            alertUser("You have been checked in. Thank you.", "green", 2000);
-            window.location.href = "https://makernexus.org";
-        }
+        
 
     });
 


### PR DESCRIPTION
Previously the javascript in the checkin form would ignore a bad response from the server. The user would think they were checked in, but they were not.

Added error code that will alert the user if not response.ok. As part of this had to move the code that did a redirect to either makernexus.org or the online waiver system into this same area.

Tested in sandbox and it worked. Deployed to production on 3.21.2024