### PR TITLE
updates checkin form question about waivers

### DIFF
--- a/Software/Database-Server_Software/www/v1/OVLcheckinout.html
+++ b/Software/Database-Server_Software/www/v1/OVLcheckinout.html
@@ -100,14 +100,14 @@
                 <div class="visitreasoncheckbox" ><label><input type="checkbox" name="visitReason[]" value="other"> Other</label></div>
             </div>
             <div class= "fieldtitle">
-                I certify that all members of my party have a signed a liability waiver on file:
+                Will you use tools or equipment at Maker Nexus?
             </div>
             <div  class="inputfield">
                 <div style="float:left; margin-left: 40px; ">
-                    <label><input type="radio" name="hasSignedWaiver" value="1"> Yes</label>
+                    <label><input type="radio" name="hasSignedWaiver" value="0"> Yes</label>
                 </div>
                 <div id="waiverbuttonno" style="float:left; ">
-                    <label><input type="radio" name="hasSignedWaiver" value="0" checked> No</label>
+                    <label><input type="radio" name="hasSignedWaiver" value="1" checked> No</label>
                 </div>
             </div>
             <div class= "fieldtitle">


### PR DESCRIPTION
There was a lot of confusion WRT the question "I certify that my party has a waiver..." The question is now changed to "Will you use tools or equipment at Maker Nexus?" with a default of No.

No will redirect to our website when the guest is done.

Yes will redirect to the waiver signing website when the guest is done.

Deployed in /v2 